### PR TITLE
Fix server startup and MongoDB connection blocking

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,33 +1,44 @@
 import express from 'express';
-import dotenv from 'dotenv';
 import cors from 'cors';
-import connectDB from './config/db.js';
 import productRoutes from './routes/productRoutes.js';
 import userRoutes from './routes/userRoutes.js';
 import orderRoutes from './routes/orderRoutes.js';
 
-
-dotenv.config();
-connectDB();
-
 const app = express();
 
+// CORS configuration
 app.use(
-    cors({
-      origin: [
-        'http://localhost:3000',
-        'https://sellby.netlify.app',
-      ],
-    })
-  );
+  cors({
+    origin: [
+      'http://localhost:3000',
+      'https://sellby.netlify.app',
+    ],
+    credentials: true,
+  })
+);
+
 app.use(express.json());
 
+// Health check endpoint (for Render and monitoring)
+app.get('/', (req, res) => {
+  res.json({
+    status: 'ok',
+    message: 'API is running',
+    timestamp: new Date().toISOString(),
+  });
+});
+
+app.get('/health', (req, res) => {
+  res.json({
+    status: 'healthy',
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+  });
+});
+
+// API Routes
 app.use('/api/products', productRoutes);
 app.use('/api/users', userRoutes);
-app.use('/api/orders', orderRoutes); 
-
-app.get('/', (req, res) => {
-    res.send('API is running...');
-});
+app.use('/api/orders', orderRoutes);
 
 export default app;

--- a/backend/src/config/db.js
+++ b/backend/src/config/db.js
@@ -2,16 +2,23 @@ import mongoose from 'mongoose';
 
 const connectDB = async () => {
   try {
-    await mongoose.connect(process.env.MONGO_URI, {
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
-      serverSelectionTimeoutMS: 30000,
-    });
-    console.log('MongoDB Connected: Atlas');
+    // Remove deprecated options - no longer needed in Mongoose 6+
+    await mongoose.connect(process.env.MONGO_URI);
+    console.log('✅ MongoDB Connected Successfully');
   } catch (error) {
-    console.error(`Error: ${error.message}`);
-    process.exit(1);
+    console.error(`❌ MongoDB Connection Error: ${error.message}`);
+    // Don't exit - let the server run even if DB fails initially
+    console.error('⚠️  Server will continue running. Check your MONGO_URI environment variable.');
   }
 };
+
+// Handle connection errors after initial connection
+mongoose.connection.on('error', (err) => {
+  console.error(`MongoDB connection error: ${err}`);
+});
+
+mongoose.connection.on('disconnected', () => {
+  console.log('MongoDB disconnected. Attempting to reconnect...');
+});
 
 export default connectDB;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,5 +1,6 @@
 import dotenv from 'dotenv';
 import app from './app.js';
+import connectDB from './config/db.js';
 import validateEnv from './config/validateEnv.js';
 
 // Load environment variables first
@@ -11,7 +12,36 @@ validateEnv();
 const PORT = process.env.PORT || 5000;
 const HOST = '0.0.0.0'; // Required for Render and other cloud platforms
 
-app.listen(PORT, HOST, () => {
+// Start server FIRST (so Render detects the port is open)
+const server = app.listen(PORT, HOST, () => {
   console.log(`🚀 Server running on ${HOST}:${PORT}`);
   console.log(`📝 Environment: ${process.env.NODE_ENV || 'development'}`);
+  console.log(`⏰ Server started at: ${new Date().toISOString()}`);
+
+  // Connect to MongoDB AFTER server is listening
+  // This prevents timeout issues on Render
+  connectDB().then(() => {
+    console.log('📊 Database connection attempted');
+  }).catch((err) => {
+    console.error('Database connection failed:', err.message);
+  });
+});
+
+// Handle server errors
+server.on('error', (error) => {
+  if (error.code === 'EADDRINUSE') {
+    console.error(`❌ Port ${PORT} is already in use`);
+  } else {
+    console.error(`❌ Server error: ${error.message}`);
+  }
+  process.exit(1);
+});
+
+// Graceful shutdown
+process.on('SIGTERM', () => {
+  console.log('SIGTERM received, closing server gracefully...');
+  server.close(() => {
+    console.log('Server closed');
+    process.exit(0);
+  });
 });


### PR DESCRIPTION
CRITICAL FIX for Render timeout:
- Server now binds to port BEFORE connecting to MongoDB
- This allows Render to detect the open port immediately
- Database connection happens asynchronously after server starts
- Server won't crash if MongoDB connection fails initially

Changes:
- Removed blocking connectDB() call from app.js
- Moved DB connection to server.js AFTER server.listen()
- Added /health endpoint for monitoring
- Removed deprecated Mongoose options (useNewUrlParser, etc)
- Made DB connection non-blocking with better error handling
- Added connection event listeners for reconnection attempts

This fixes the 'Port scan timeout' error on Render deployments.